### PR TITLE
Remove dependency on liboobs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,12 +11,6 @@ find_package(Qt5Widgets REQUIRED QUIET)
 find_package(lxqt REQUIRED QUIET)
 find_package(KF5WindowSystem REQUIRED QUIET)
 
-find_package(PkgConfig)
-pkg_check_modules(OOBS REQUIRED
-    glib-2.0
-    liboobs-1
-)
-
 include(LXQtCompilerSettings NO_POLICY_SCOPE)
 include(LXQtTranslate)
 

--- a/lxqt-admin-time/CMakeLists.txt
+++ b/lxqt-admin-time/CMakeLists.txt
@@ -10,6 +10,7 @@ set ( lxqt-admin-time_HDRS
     timeadmindialog.h
     datetime.h
     timezone.h
+    timedatectl.h
 )
 
 set ( lxqt-admin-time_SRCS
@@ -17,6 +18,7 @@ set ( lxqt-admin-time_SRCS
     timeadmindialog.cpp
     datetime.cpp
     timezone.cpp
+    timedatectl.cpp
 )
 
 set ( lxqt-admin-time_MOCS

--- a/lxqt-admin-time/CMakeLists.txt
+++ b/lxqt-admin-time/CMakeLists.txt
@@ -75,6 +75,7 @@ add_executable(lxqt-admin-time
 target_link_libraries(lxqt-admin-time
     KF5::WindowSystem
     Qt5::Widgets
+    Qt5::DBus
     lxqt
 )
 

--- a/lxqt-admin-time/CMakeLists.txt
+++ b/lxqt-admin-time/CMakeLists.txt
@@ -3,7 +3,6 @@ project(lxqt-admin-time)
 # build static helper class first
 include_directories (
     ${CMAKE_CURRENT_BINARY_DIR}
-    ${OOBS_INCLUDE_DIRS}
 )
 
 set ( lxqt-admin-time_HDRS
@@ -77,7 +76,6 @@ target_link_libraries(lxqt-admin-time
     KF5::WindowSystem
     Qt5::Widgets
     lxqt
-    ${OOBS_LIBRARIES}
 )
 
 install(TARGETS lxqt-admin-time RUNTIME DESTINATION bin)

--- a/lxqt-admin-time/datetime.h
+++ b/lxqt-admin-time/datetime.h
@@ -34,38 +34,46 @@ namespace Ui {
 class DateTime;
 }
 
-class DateTime : public QWidget
+class DateTimePage : public QWidget
 {
     Q_OBJECT
 
 public:
-    explicit DateTime(QWidget *parent = 0);
-    ~DateTime();
+    explicit DateTimePage(bool useNtp, bool localRtc, QWidget *parent = 0);
+    ~DateTimePage();
 
-    enum modified_enum {M_DATE = 0x1, M_TIME = 0x2};
-    Q_DECLARE_FLAGS(modified_t, modified_enum)
+    enum ModifiedFlag {M_DATE = (1 << 0), M_TIME = (1 << 1), M_NTP = (1 << 2), M_LOCAL_RTC = (1 << 3)};
+    Q_DECLARE_FLAGS(ModifiedFlags,ModifiedFlag)
+
+    ModifiedFlags modified() const
+    {
+        return mModified;
+    }
 
     QDateTime dateTime() const;
-    inline modified_t modified() const {return mModified;}
+    bool useNtp() const;
+    bool localRtc() const;
 
 public Q_SLOTS:
     void reload();
-
 
 private Q_SLOTS:
     void on_edit_time_userTimeChanged(const QTime &time);
     void timeout();
     void on_calendar_selectionChanged();
+    void on_ntp_toggled(bool toggled);
+    void on_localRTC_toggled(bool toggled);
 
 Q_SIGNALS:
-    void changed(bool);
+    void changed();
 
 private:
     Ui::DateTime *ui;
     QTimer * mTimer;
-    modified_t  mModified;
+    bool mUseNtp;
+    bool mLocalRtc;
+    ModifiedFlags mModified;
 };
 
-Q_DECLARE_OPERATORS_FOR_FLAGS(DateTime::modified_t)
 
 #endif // DATETIME_H

--- a/lxqt-admin-time/datetime.ui
+++ b/lxqt-admin-time/datetime.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>354</width>
-    <height>308</height>
+    <width>365</width>
+    <height>323</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -16,7 +16,7 @@
     <height>50</height>
    </size>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,1,0,0,0">
    <item>
     <widget class="QLabel" name="label_time">
      <property name="text">
@@ -65,6 +65,20 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="ntp">
+     <property name="text">
+      <string>Enable network time synchronization (NTP)</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="localRTC">
+     <property name="text">
+      <string>RTC is in local time</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -77,24 +91,41 @@
      </property>
     </spacer>
    </item>
-   <item>
-    <widget class="QLabel" name="label">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Saving changes requires admin permissions.&lt;br&gt;You will be requested after clicking close button&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>ntp</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>calendar</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>221</x>
+     <y>269</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>228</x>
+     <y>162</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>ntp</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>edit_time</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>105</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>173</x>
+     <y>55</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/lxqt-admin-time/timeadmindialog.cpp
+++ b/lxqt-admin-time/timeadmindialog.cpp
@@ -31,10 +31,10 @@
 #include <QMessageBox>
 #include <QDateTime>
 #include <QMap>
+#include <QDebug>
 
 #include "datetime.h"
 #include "timezone.h"
-
 
 #define ZONETAB_PATH "/usr/share/zoneinfo/zone.tab"
 
@@ -107,6 +107,8 @@ void TimeAdminDialog::closeEvent(QCloseEvent *event)
 
 void TimeAdminDialog::loadTimeZones(QStringList & timeZones, QString & currentTimezone)
 {
+    currentTimezone = mTimeDateCtl.timeZone();
+
     timeZones.clear();
     QFile file(ZONETAB_PATH);
     if(file.open(QIODevice::ReadOnly))
@@ -124,17 +126,18 @@ void TimeAdminDialog::loadTimeZones(QStringList & timeZones, QString & currentTi
         }
         file.close();
     }
-    currentTimezone = QString::fromLatin1(oobs_time_config_get_timezone(mTimeConfig));
 }
 
 
 
 void TimeAdminDialog::saveChangesToSystem()
 {
-    QByteArray timeZone = mTimezoneWidget->timezone().toLatin1();
+    QString timeZone = mTimezoneWidget->timezone();
     // FIXME: currently timezone settings does not work. is this a bug of system-tools-backend?
-    if(!timeZone.isEmpty() && mWidgetsModified.testFlag(M_TIMEZONE))
-        oobs_time_config_set_timezone(mTimeConfig, timeZone.constData());
+    if(!timeZone.isEmpty() && mWidgetsModified.testFlag(M_TIMEZONE)) {
+        mTimeDateCtl.setTimeZone(timeZone);
+        mTimeDateCtl.commit();
+    }
 
     if(mWidgetsModified.testFlag(M_TIMEDATE))
     {

--- a/lxqt-admin-time/timeadmindialog.cpp
+++ b/lxqt-admin-time/timeadmindialog.cpp
@@ -119,15 +119,19 @@ void TimeAdminDialog::loadTimeZones(QStringList & timeZones, QString & currentTi
 
 void TimeAdminDialog::saveChangesToSystem()
 {
+    QString errorMessage;
     QString timeZone = mTimezoneWidget->timezone();
     // FIXME: currently timezone settings does not work. is this a bug of system-tools-backend?
     if(!timeZone.isEmpty() && mWidgetsModified.testFlag(M_TIMEZONE)) {
-        mTimeDateCtl.setTimeZone(timeZone);
+        if(false == mTimeDateCtl.setTimeZone(timeZone, errorMessage)) {
+            QMessageBox::critical(this, tr("Error"), errorMessage);
+        }
     }
 
     if(mWidgetsModified.testFlag(M_TIMEDATE))
     {
-        mTimeDateCtl.setDateTime(mDateTimeWidget->dateTime());
+        if(false == mTimeDateCtl.setDateTime(mDateTimeWidget->dateTime(), errorMessage)) {
+            QMessageBox::critical(this, tr("Error"), errorMessage);
+        }
     }
-    mTimeDateCtl.commit();
 }

--- a/lxqt-admin-time/timeadmindialog.h
+++ b/lxqt-admin-time/timeadmindialog.h
@@ -30,6 +30,8 @@
 #include <oobs/oobs-timeconfig.h>
 #include <oobs/oobs-ntpconfig.h>
 #include <oobs/oobs-ntpserver.h>
+#include "timedatectl.h"
+
 
 class DateTime;
 class Timezone;
@@ -59,6 +61,7 @@ private:
     void showChangedStar();
 
 private:
+    TimeDateCtl mTimeDateCtl;
     OobsTimeConfig* mTimeConfig;
     DateTime * mDateTimeWidget;
     Timezone * mTimezoneWidget;

--- a/lxqt-admin-time/timeadmindialog.h
+++ b/lxqt-admin-time/timeadmindialog.h
@@ -28,8 +28,8 @@
 #include <LXQt/ConfigDialog>
 #include "timedatectl.h"
 
-class DateTime;
-class Timezone;
+class DateTimePage;
+class TimezonePage;
 
 class TimeAdminDialog: public LXQt::ConfigDialog
 {
@@ -39,15 +39,9 @@ public:
     TimeAdminDialog(QWidget * parent = NULL) ;
     ~TimeAdminDialog();
 
-
-    typedef enum  {M_TIMEDATE = 1 , M_TIMEZONE = 0x2} widgets_modified_enum;
-    Q_DECLARE_FLAGS(widgets_modified_t, widgets_modified_enum)
-
-protected:
-    virtual void closeEvent(QCloseEvent  * event);
-
 private Q_SLOTS:
-    void onChanged(bool);
+    void onChanged();
+    void onButtonClicked(QDialogButtonBox::StandardButton button);
 
 private:
     void saveChangesToSystem();
@@ -56,11 +50,7 @@ private:
 
 private:
     TimeDateCtl mTimeDateCtl;
-    DateTime * mDateTimeWidget;
-    Timezone * mTimezoneWidget;
+    DateTimePage * mDateTimeWidget;
+    TimezonePage * mTimezoneWidget;
     QString mWindowTitle;
-    widgets_modified_t mWidgetsModified;
 };
-
-Q_DECLARE_METATYPE(TimeAdminDialog::widgets_modified_enum)
-Q_DECLARE_OPERATORS_FOR_FLAGS(TimeAdminDialog::widgets_modified_t)

--- a/lxqt-admin-time/timeadmindialog.h
+++ b/lxqt-admin-time/timeadmindialog.h
@@ -26,12 +26,7 @@
  * END_COMMON_COPYRIGHT_HEADER */
 
 #include <LXQt/ConfigDialog>
-#include <glib.h>
-#include <oobs/oobs-timeconfig.h>
-#include <oobs/oobs-ntpconfig.h>
-#include <oobs/oobs-ntpserver.h>
 #include "timedatectl.h"
-
 
 class DateTime;
 class Timezone;
@@ -55,17 +50,14 @@ private Q_SLOTS:
     void onChanged(bool);
 
 private:
-    bool logInUser();
     void saveChangesToSystem();
     void loadTimeZones(QStringList & timeZones, QString & currentTimezone);
     void showChangedStar();
 
 private:
     TimeDateCtl mTimeDateCtl;
-    OobsTimeConfig* mTimeConfig;
     DateTime * mDateTimeWidget;
     Timezone * mTimezoneWidget;
-    bool mUserLogedIn;
     QString mWindowTitle;
     widgets_modified_t mWidgetsModified;
 };

--- a/lxqt-admin-time/timedatectl.cpp
+++ b/lxqt-admin-time/timedatectl.cpp
@@ -1,0 +1,35 @@
+#include "timedatectl.h"
+#include <QProcess>
+#include <QDebug>
+
+TimeDateCtl::TimeDateCtl()
+{
+    QProcess timedatectl;
+    timedatectl.start(QStringLiteral("timedatectl"));
+    timedatectl.waitForFinished();
+    while(!timedatectl.atEnd()) {
+        QString line = timedatectl.readLine().trimmed();
+        int findTZ = line.indexOf(QLatin1String("Time zone:"));
+        if(findTZ != -1) {
+            findTZ += 10;
+            while(line[findTZ] == ' ')
+                ++findTZ;
+            int space = line.indexOf(' ', findTZ);
+            mTimeZone = line.mid(findTZ, space - findTZ);
+            break;
+        }
+    }
+    timedatectl.close();
+}
+
+bool TimeDateCtl::commit()
+{
+    QProcess timedatectl;
+    QStringList args;
+    if(mTimeZoneChanged) {
+        args << "set-timezone" << mTimeZone;
+    }
+    timedatectl.start(QStringLiteral("timedatectl"), args);
+    timedatectl.waitForFinished();
+    return timedatectl.exitCode() == 0;
+}

--- a/lxqt-admin-time/timedatectl.cpp
+++ b/lxqt-admin-time/timedatectl.cpp
@@ -24,12 +24,21 @@ TimeDateCtl::TimeDateCtl()
 
 bool TimeDateCtl::commit()
 {
+    bool success = true;
     QProcess timedatectl;
     QStringList args;
     if(mTimeZoneChanged) {
-        args << "set-timezone" << mTimeZone;
+        timedatectl.start(QStringLiteral("timedatectl"), QStringList() << "set-timezone" << mTimeZone);
+        timedatectl.waitForFinished();
+        success = timedatectl.exitCode() == 0;
     }
-    timedatectl.start(QStringLiteral("timedatectl"), args);
-    timedatectl.waitForFinished();
-    return timedatectl.exitCode() == 0;
+    if(!success)
+        return success;
+
+    if(mTimeChanged) {
+        timedatectl.start(QStringLiteral("timedatectl"), QStringList() << "set-time" << mDateTime.toString("yyyy-MM-dd hh:mm:ss"));
+        timedatectl.waitForFinished();
+        success = timedatectl.exitCode() == 0;
+    }
+    return success;
 }

--- a/lxqt-admin-time/timedatectl.cpp
+++ b/lxqt-admin-time/timedatectl.cpp
@@ -49,3 +49,37 @@ bool TimeDateCtl::setDateTime(QDateTime dateTime, QString& errorMessage)
     }
     return true;
 }
+
+bool TimeDateCtl::useNtp() const
+{
+    return mIface->property("NTP").toBool();
+}
+
+bool TimeDateCtl::setUseNtp(bool value, QString& errorMessage)
+{
+    mIface->call("SetNTP", value, true);
+    QDBusError err = mIface->lastError();
+    if(err.isValid())
+    {
+        errorMessage = err.message();
+        return false;
+    }
+    return true;
+}
+
+bool TimeDateCtl::localRtc() const
+{
+    return mIface->property("LocalRTC").toBool();
+}
+
+bool TimeDateCtl::setLocalRtc(bool value, QString& errorMessage)
+{
+    mIface->call("SetLocalRTC", value, false, true);
+    QDBusError err = mIface->lastError();
+    if(err.isValid())
+    {
+        errorMessage = err.message();
+        return false;
+    }
+    return true;
+}

--- a/lxqt-admin-time/timedatectl.h
+++ b/lxqt-admin-time/timedatectl.h
@@ -12,28 +12,12 @@ public:
     explicit TimeDateCtl();
     ~TimeDateCtl();
 
-    QString timeZone() const {
-        return mTimeZone;
-    }
+    QString timeZone() const;
 
-    void setTimeZone(QString timeZone) {
-        mTimeZone = timeZone;
-        mTimeZoneChanged = true;
-    }
-
-    void setDateTime(QDateTime dateTime) {
-        mDateTime = dateTime;
-        mTimeChanged = true;
-    }
-
-    // really commit the changes to the system
-    bool commit();
+    bool setTimeZone(QString timeZone, QString& errorMessage);
+    bool setDateTime(QDateTime dateTime, QString& errorMessage);
 
 private:
-    bool mTimeZoneChanged;
-    QString mTimeZone;
-    bool mTimeChanged;
-    QDateTime mDateTime;
     QDBusInterface* mIface;
 };
 

--- a/lxqt-admin-time/timedatectl.h
+++ b/lxqt-admin-time/timedatectl.h
@@ -1,0 +1,36 @@
+#ifndef TIMEDATECTL_H
+#define TIMEDATECTL_H
+
+#include <QString>
+#include <QDateTime>
+
+class TimeDateCtl
+{
+public:
+    explicit TimeDateCtl();
+
+    QString timeZone() const {
+        return mTimeZone;
+    }
+
+    void setTimeZone(QString timeZone) {
+        mTimeZone = timeZone;
+        mTimeZoneChanged = true;
+    }
+
+    void setDateTime(QDateTime dateTime) {
+        mDateTime = dateTime;
+        mTimeChanged = true;
+    }
+
+    // really commit the changes to the system
+    bool commit();
+
+private:
+    bool mTimeZoneChanged;
+    QString mTimeZone;
+    bool mTimeChanged;
+    QDateTime mDateTime;
+};
+
+#endif // TIMEDATECTL_H

--- a/lxqt-admin-time/timedatectl.h
+++ b/lxqt-admin-time/timedatectl.h
@@ -12,9 +12,15 @@ public:
     explicit TimeDateCtl();
     ~TimeDateCtl();
 
-    QString timeZone() const;
+    bool useNtp() const;
+    bool setUseNtp(bool value, QString& errorMessage);
 
+    bool localRtc() const;
+    bool setLocalRtc(bool value, QString& errorMessage);
+
+    QString timeZone() const;
     bool setTimeZone(QString timeZone, QString& errorMessage);
+
     bool setDateTime(QDateTime dateTime, QString& errorMessage);
 
 private:

--- a/lxqt-admin-time/timedatectl.h
+++ b/lxqt-admin-time/timedatectl.h
@@ -4,10 +4,13 @@
 #include <QString>
 #include <QDateTime>
 
+class QDBusInterface;
+
 class TimeDateCtl
 {
 public:
     explicit TimeDateCtl();
+    ~TimeDateCtl();
 
     QString timeZone() const {
         return mTimeZone;
@@ -31,6 +34,7 @@ private:
     QString mTimeZone;
     bool mTimeChanged;
     QDateTime mDateTime;
+    QDBusInterface* mIface;
 };
 
 #endif // TIMEDATECTL_H

--- a/lxqt-admin-time/timezone.cpp
+++ b/lxqt-admin-time/timezone.cpp
@@ -28,7 +28,7 @@
 #include "timezone.h"
 #include "ui_timezone.h"
 
-Timezone::Timezone(const QStringList & zones, const QString & currentimezone, QWidget *parent) :
+TimezonePage::TimezonePage(const QStringList & zones, const QString & currentimezone, QWidget *parent) :
     QWidget(parent),
     ui(new Ui::Timezone),
     mZoneChanged(false),
@@ -47,12 +47,12 @@ Timezone::Timezone(const QStringList & zones, const QString & currentimezone, QW
     reload();
 }
 
-Timezone::~Timezone()
+TimezonePage::~TimezonePage()
 {
     delete ui;
 }
 
-void Timezone::reload()
+void TimezonePage::reload()
 {
     ui->list_zones->setCurrentRow(-1);
     mZoneChanged = false;
@@ -60,10 +60,10 @@ void Timezone::reload()
     if (list.count())
         ui->list_zones->setCurrentItem(list.at(0));
 
-    emit changed(mZoneChanged);
+    emit changed();
 }
 
-QString Timezone::timezone() const
+QString TimezonePage::timezone() const
 {
     if (ui->list_zones->currentItem())
         return ui->list_zones->currentItem()->text();
@@ -71,16 +71,17 @@ QString Timezone::timezone() const
         return QString();
 }
 
-void Timezone::on_list_zones_itemActivated(QListWidgetItem * item)
+void TimezonePage::on_list_zones_itemSelectionChanged()
 {
-    bool old = mZoneChanged;
+    QList<QListWidgetItem*> selected = ui->list_zones->selectedItems();
+    if(selected.empty())
+        return;
+    QListWidgetItem *item = selected.first();
     mZoneChanged = item->text() != ui->label_timezone->text();
-
-    if (mZoneChanged != old)
-        emit changed(mZoneChanged);
+    emit changed();
 }
 
-void Timezone::on_edit_filter_textChanged(const QString &arg1)
+void TimezonePage::on_edit_filter_textChanged(const QString &arg1)
 {
     QRegExp reg(arg1, Qt::CaseInsensitive,QRegExp::Wildcard);
     ui->list_zones->clear();

--- a/lxqt-admin-time/timezone.h
+++ b/lxqt-admin-time/timezone.h
@@ -35,13 +35,13 @@ class Timezone;
 }
 
 class QListWidgetItem;
-class Timezone : public QWidget
+class TimezonePage : public QWidget
 {
     Q_OBJECT
 
 public:
-    explicit Timezone(const QStringList & zones, const QString & currentimezone, QWidget *parent = 0);
-    ~Timezone();
+    explicit TimezonePage(const QStringList & zones, const QString & currentimezone, QWidget *parent = 0);
+    ~TimezonePage();
     QString timezone() const;
     inline bool isChanged() const {return mZoneChanged;}
 
@@ -49,10 +49,10 @@ public slots:
     void reload();
 
 Q_SIGNALS:
-    void changed(bool);
+    void changed();
 
 private slots:
-    void on_list_zones_itemActivated(QListWidgetItem *item);
+    void on_list_zones_itemSelectionChanged();
     void on_edit_filter_textChanged(const QString &arg1);
 
 private:

--- a/lxqt-admin-time/timezone.ui
+++ b/lxqt-admin-time/timezone.ui
@@ -42,22 +42,6 @@
    <item>
     <widget class="QListWidget" name="list_zones"/>
    </item>
-   <item>
-    <widget class="QLabel" name="label">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Saving changes requires admin permissions.&lt;br&gt;You will be requested after clicking close button&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <resources/>

--- a/lxqt-admin-user/CMakeLists.txt
+++ b/lxqt-admin-user/CMakeLists.txt
@@ -74,3 +74,13 @@ target_link_libraries(lxqt-admin-user
 
 install(TARGETS lxqt-admin-user RUNTIME DESTINATION bin)
 install(FILES ${DESKTOP_FILES} DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
+
+# for policykit
+# manpage for pcmanfm-qt
+configure_file(
+    "org.lxqt.lxqt-admin-user.policy.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/org.lxqt.lxqt-admin-user.policy"
+    @ONLY
+)
+install(PROGRAMS "lxqt-admin-user-helper" DESTINATION bin)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/org.lxqt.lxqt-admin-user.policy" DESTINATION "share/polkit-1/actions")

--- a/lxqt-admin-user/CMakeLists.txt
+++ b/lxqt-admin-user/CMakeLists.txt
@@ -3,7 +3,6 @@ project(lxqt-admin-user)
 # build static helper class first
 include_directories (
     ${CMAKE_CURRENT_BINARY_DIR}
-    ${OOBS_INCLUDE_DIRS}
 )
 
 set ( lxqt-admin-user_SRCS
@@ -11,12 +10,14 @@ set ( lxqt-admin-user_SRCS
     mainwindow.cpp
     userdialog.cpp
     groupdialog.cpp
+    usermanager.cpp
 )
 
 set ( lxqt-admin-user_MOCS
     mainwindow.h
     userdialog.h
     groupdialog.h
+    usermanager.h
 )
 
 set( lxqt-admin-user_UIS
@@ -69,7 +70,6 @@ target_link_libraries(lxqt-admin-user
     KF5::WindowSystem
     Qt5::Widgets
     lxqt
-    ${OOBS_LIBRARIES}
 )
 
 install(TARGETS lxqt-admin-user RUNTIME DESTINATION bin)

--- a/lxqt-admin-user/groupdialog.cpp
+++ b/lxqt-admin-user/groupdialog.cpp
@@ -36,7 +36,6 @@ GroupDialog::GroupDialog(UserManager* userManager, GroupInfo* group, QWidget *pa
     ui.gid->setValue(group->gid());
 
     const QStringList& members = group->members(); // all users in this group
-    qDebug() << members;
     // load all users
     for(const UserInfo* user: userManager->users())
     {
@@ -69,26 +68,12 @@ void GroupDialog::accept()
     mGroup->setGid(ui.gid->value());
 
     // update users
-#if 0
-    GList* groupUsers = oobs_group_get_users(mGroup); // all users in this group
-    int rowCount = ui.userList->count();
-    for(int row = 0; row < rowCount; ++row)
-    {
+    mGroup->removeAllMemberss();
+    for(int row = 0; row < ui.userList->count(); ++row) {
         QListWidgetItem* item = ui.userList->item(row);
-        QVariant obj = item->data(Qt::UserRole);
-        OobsUser* user = OOBS_USER(obj.value<void*>());
-        if(g_list_find(groupUsers, user)) // the user belongs to this group previously
-        {
-            if(item->checkState() == Qt::Unchecked) // it's unchecked, remove it
-                oobs_group_remove_user(mGroup, user);
-        }
-        else // the user does not belong to this group previously
-        {
-            if(item->checkState() == Qt::Checked) // it's checked, we want it!
-                oobs_group_add_user(mGroup, user);
+        if(item->checkState() == Qt::Checked) {
+            mGroup->addMember(item->text());
         }
     }
-    g_list_free(groupUsers);
-#endif
     QDialog::accept();
 }

--- a/lxqt-admin-user/groupdialog.cpp
+++ b/lxqt-admin-user/groupdialog.cpp
@@ -21,6 +21,7 @@
 #include "groupdialog.h"
 #include <QMessageBox>
 #include "usermanager.h"
+#include <QDebug>
 
 #define DEFAULT_GID_MIN 1000
 #define DEFAULT_GID_MAX 32768
@@ -34,33 +35,22 @@ GroupDialog::GroupDialog(UserManager* userManager, GroupInfo* group, QWidget *pa
     ui.groupName->setText(group->name());
     ui.gid->setValue(group->gid());
 
-#if 0
-    GList* groupUsers = oobs_group_get_users(mGroup); // all users in this group
+    const QStringList& members = group->members(); // all users in this group
+    qDebug() << members;
     // load all users
-    OobsUsersConfig* usersConfig = OOBS_USERS_CONFIG(oobs_users_config_get());
-    OobsList* users = oobs_users_config_get_users(usersConfig);
-    if(users)
+    for(const UserInfo* user: userManager->users())
     {
-        OobsListIter it;
-        gboolean valid = oobs_list_get_iter_first(users, &it);
-        while(valid)
-        {
-            OobsUser* user = OOBS_USER(oobs_list_get(users, &it));
-            QListWidgetItem* item = new QListWidgetItem();
-            item->setText(oobs_user_get_login_name(user));
-            item->setFlags(Qt::ItemIsEnabled|Qt::ItemIsUserCheckable|Qt::ItemIsSelectable);
-            if(g_list_find(groupUsers, user)) // the user is in this group
-                item->setCheckState(Qt::Checked);
-            else
-                item->setCheckState(Qt::Unchecked);
-            QVariant obj = QVariant::fromValue<void*>(user);
-            item->setData(Qt::UserRole, obj);
-            ui.userList->addItem(item);
-            valid = oobs_list_iter_next(users, &it);
-        }
+        QListWidgetItem* item = new QListWidgetItem();
+        item->setText(user->name());
+        item->setFlags(Qt::ItemIsEnabled|Qt::ItemIsUserCheckable|Qt::ItemIsSelectable);
+        if(members.indexOf(user->name()) != -1) // the user is in this group
+            item->setCheckState(Qt::Checked);
+        else
+            item->setCheckState(Qt::Unchecked);
+        QVariant obj = QVariant::fromValue<void*>((void*)user);
+        item->setData(Qt::UserRole, obj);
+        ui.userList->addItem(item);
     }
-    g_list_free(groupUsers);
-#endif
 }
 
 GroupDialog::~GroupDialog()

--- a/lxqt-admin-user/groupdialog.h
+++ b/lxqt-admin-user/groupdialog.h
@@ -23,32 +23,24 @@
 
 #include <QDialog>
 #include "ui_groupdialog.h"
-#include <glib.h>
-#include <oobs/oobs-usersconfig.h>
-#include <oobs/oobs-groupsconfig.h>
+
+class GroupInfo;
+class UserManager;
 
 class GroupDialog : public QDialog
 {
     Q_OBJECT
 
 public:
-    GroupDialog(OobsGroup* group = NULL, QWidget *parent = NULL, Qt::WindowFlags f = 0);
+    GroupDialog(UserManager* userManager, GroupInfo* group, QWidget *parent = nullptr, Qt::WindowFlags f = 0);
     ~GroupDialog();
-
-    OobsGroup* group()
-    {
-        return mGroup;
-    }
 
     virtual void accept();
 
 private:
-    bool hasUser(OobsUser* user);
-
-private:
     Ui::GroupDialog ui;
-    OobsGroup* mGroup;
-    gid_t mOldGId;
+    UserManager* mUserManager;
+    GroupInfo* mGroup;
 };
 
 #endif // GROUPDIALOG_H

--- a/lxqt-admin-user/groupdialog.ui
+++ b/lxqt-admin-user/groupdialog.ui
@@ -26,6 +26,9 @@
    </item>
    <item row="1" column="1">
     <widget class="QSpinBox" name="gid">
+     <property name="specialValueText">
+      <string>Default</string>
+     </property>
      <property name="maximum">
       <number>32768</number>
      </property>

--- a/lxqt-admin-user/lxqt-admin-user-helper
+++ b/lxqt-admin-user/lxqt-admin-user-helper
@@ -1,0 +1,12 @@
+#!/bin/sh
+case "$1" in
+# we only allow executing these commands
+useradd|usermod|userdel|groupadd|groupmod|groupdel)
+    # TODO: platforms using different commands can add workarounds here.
+    exec $*
+    ;;
+*)
+    echo "Command '$1' is not allowed!"
+    exit 1
+    ;;
+esac

--- a/lxqt-admin-user/lxqt-admin-user-helper
+++ b/lxqt-admin-user/lxqt-admin-user-helper
@@ -1,8 +1,9 @@
 #!/bin/sh
 case "$1" in
 # we only allow executing these commands
-useradd|usermod|userdel|groupadd|groupmod|groupdel)
-    # TODO: platforms using different commands can add workarounds here.
+useradd|usermod|userdel|groupadd|groupmod|groupdel|passwd|gpasswd)
+    # TODO: platforms using different commands can add wrapper scripts here.
+    export LC_ALL=C
     exec $*
     ;;
 *)

--- a/lxqt-admin-user/lxqt-admin-user-helper
+++ b/lxqt-admin-user/lxqt-admin-user-helper
@@ -4,7 +4,7 @@ case "$1" in
 useradd|usermod|userdel|groupadd|groupmod|groupdel|passwd|gpasswd)
     # TODO: platforms using different commands can add wrapper scripts here.
     export LC_ALL=C
-    exec $*
+    exec "$@"
     ;;
 *)
     echo "Command '$1' is not allowed!"

--- a/lxqt-admin-user/mainwindow.cpp
+++ b/lxqt-admin-user/mainwindow.cpp
@@ -38,15 +38,13 @@ MainWindow::MainWindow():
     connect(ui.actionDelete, SIGNAL(triggered(bool)), SLOT(onDelete()));
     connect(ui.actionProperties, SIGNAL(triggered(bool)), SLOT(onEditProperties()));
     connect(ui.actionChangePasswd, SIGNAL(triggered(bool)), SLOT(onChangePasswd()));
+    connect(ui.actionRefresh, SIGNAL(triggered(bool)), SLOT(reload()));
 
-    connect(ui.actionRefresh, SIGNAL(triggered(bool)), SLOT(reloadUsers()));
-    connect(ui.actionRefresh, SIGNAL(triggered(bool)), SLOT(reloadGroups()));
+    connect(ui.userList, &QListWidget::activated, this, &MainWindow::onRowActivated);
+    connect(ui.groupList, &QListWidget::activated, this, &MainWindow::onRowActivated);
 
-    connect(mUserManager, &UserManager::usersChanged, this, &MainWindow::reloadUsers);
-    connect(mUserManager, &UserManager::groupsChanged, this, &MainWindow::reloadGroups);
-
-    reloadUsers();
-    reloadGroups();
+    connect(mUserManager, &UserManager::changed, this, &MainWindow::reload);
+    reload();
 }
 
 MainWindow::~MainWindow()
@@ -90,8 +88,14 @@ void MainWindow::reloadGroups()
         QVariant obj = QVariant::fromValue<void*>((void*)group);
         item->setData(0, Qt::UserRole, obj);
         item->setData(1, Qt::DisplayRole, group->gid());
+        item->setData(2, Qt::DisplayRole, group->members().join(", "));
         ui.groupList->addTopLevelItem(item);
     }
+}
+
+void MainWindow::reload() {
+    reloadUsers();
+    reloadGroups();
 }
 
 UserInfo *MainWindow::userFromItem(QTreeWidgetItem *item)
@@ -215,6 +219,11 @@ void MainWindow::onChangePasswd() {
             mUserManager->changePassword(group, newPasswd);
         }
     }
+}
+
+void MainWindow::onRowActivated(const QModelIndex& index)
+{
+    onEditProperties();
 }
 
 void MainWindow::onEditProperties()

--- a/lxqt-admin-user/mainwindow.cpp
+++ b/lxqt-admin-user/mainwindow.cpp
@@ -96,7 +96,7 @@ UserInfo *MainWindow::userFromItem(QTreeWidgetItem *item)
         QVariant obj = item->data(0, Qt::UserRole);
         return reinterpret_cast<UserInfo*>(obj.value<void*>());
     }
-    return NULL;
+    return nullptr;
 }
 
 GroupInfo* MainWindow::groupFromItem(QTreeWidgetItem *item)
@@ -106,7 +106,7 @@ GroupInfo* MainWindow::groupFromItem(QTreeWidgetItem *item)
         QVariant obj = item->data(0, Qt::UserRole);
         return reinterpret_cast<GroupInfo*>(obj.value<void*>());
     }
-    return NULL;
+    return nullptr;
 }
 
 void MainWindow::onAdd()
@@ -136,8 +136,7 @@ void MainWindow::onDelete()
     if(ui.tabWidget->currentIndex() == PageUsers)
     {
         QTreeWidgetItem* item = ui.userList->currentItem();
-        QString userName = item->text(0);
-        UserInfo* user = mUserManager->findUserInfo(userName);
+        UserInfo* user = userFromItem(item);
         if(user)
         {
             if(QMessageBox::question(this, tr("Confirm"), tr("Are you sure you want to delete the selected user?"), QMessageBox::Ok|QMessageBox::Cancel) == QMessageBox::Ok)
@@ -149,8 +148,7 @@ void MainWindow::onDelete()
     else if(ui.tabWidget->currentIndex() == PageGroups)
     {
         QTreeWidgetItem* item = ui.groupList->currentItem();
-        QString groupName = item->text(0);
-        GroupInfo* group = mUserManager->findGroupInfo(groupName);
+        GroupInfo* group = groupFromItem(item);
         if(group)
         {
             if(QMessageBox::question(this, tr("Confirm"), tr("Are you sure you want to delete the selected group?"), QMessageBox::Ok|QMessageBox::Cancel) == QMessageBox::Ok)
@@ -166,11 +164,10 @@ void MainWindow::onEditProperties()
     if(ui.tabWidget->currentIndex() == PageUsers)
     {
         QTreeWidgetItem* item = ui.userList->currentItem();
-        QString name = item->text(0);
-        UserInfo* user = mUserManager->findUserInfo(name);
+        UserInfo* user = userFromItem(item);
         if(user) {
             UserInfo newSettings(*user);
-            UserDialog dlg(mUserManager, &newSettings);
+            UserDialog dlg(mUserManager, &newSettings, this);
             if(dlg.exec() == QDialog::Accepted)
             {
                 mUserManager->modifyUser(user, &newSettings);
@@ -180,11 +177,10 @@ void MainWindow::onEditProperties()
     else if(ui.tabWidget->currentIndex() == PageGroups)
     {
         QTreeWidgetItem* item = ui.groupList->currentItem();
-        QString name = item->text(0);
-        GroupInfo* group = mUserManager->findGroupInfo(name);
+        GroupInfo* group = groupFromItem(item);
         if(group) {
             GroupInfo newSettings(*group);
-            GroupDialog dlg(mUserManager, &newSettings);
+            GroupDialog dlg(mUserManager, &newSettings, this);
             if(dlg.exec() == QDialog::Accepted)
             {
                 mUserManager->modifyGroup(group, &newSettings);

--- a/lxqt-admin-user/mainwindow.h
+++ b/lxqt-admin-user/mainwindow.h
@@ -46,6 +46,7 @@ public:
 private:
     UserInfo* userFromItem(QTreeWidgetItem* item);
     GroupInfo* groupFromItem(QTreeWidgetItem *item);
+    bool getNewPassword(const QString& name, QByteArray& passwd);
 
 private Q_SLOTS:
     void reloadUsers();
@@ -53,6 +54,7 @@ private Q_SLOTS:
     void onAdd();
     void onDelete();
     void onEditProperties();
+    void onChangePasswd();
 
 private:
     Ui::MainWindow ui;

--- a/lxqt-admin-user/mainwindow.h
+++ b/lxqt-admin-user/mainwindow.h
@@ -24,9 +24,9 @@
 #include <QMainWindow>
 #include "ui_mainwindow.h"
 
-#include <glib.h>
-#include <oobs/oobs-usersconfig.h>
-#include <oobs/oobs-groupsconfig.h>
+class UserInfo;
+class GroupInfo;
+class UserManager;
 
 class MainWindow : public QMainWindow
 {
@@ -44,34 +44,19 @@ public:
     virtual ~MainWindow();
 
 private:
-    void loadUsers();
-    void loadGroups();
-    OobsUser* userFromItem(QTreeWidgetItem* item);
-    OobsGroup* groupFromItem(QTreeWidgetItem *item);
-
-    template <class T>
-    bool authenticate(T* obj);
-
-    static void onUsersConfigChanged(OobsObject* obj, MainWindow* _this)
-    {
-        _this->loadUsers();
-    }
-
-    static void onGroupsConfigChanged(OobsObject* obj, MainWindow* _this)
-    {
-        _this->loadGroups();
-    }
+    UserInfo* userFromItem(QTreeWidgetItem* item);
+    GroupInfo* groupFromItem(QTreeWidgetItem *item);
 
 private Q_SLOTS:
+    void reloadUsers();
+    void reloadGroups();
     void onAdd();
     void onDelete();
     void onEditProperties();
-    void onRefresh();
 
 private:
     Ui::MainWindow ui;
-    OobsUsersConfig* mUsersConfig;
-    OobsGroupsConfig* mGroupsConfig;
+    UserManager* mUserManager;
 };
 
 #endif // MAINWINDOW_H

--- a/lxqt-admin-user/mainwindow.h
+++ b/lxqt-admin-user/mainwindow.h
@@ -47,14 +47,16 @@ private:
     UserInfo* userFromItem(QTreeWidgetItem* item);
     GroupInfo* groupFromItem(QTreeWidgetItem *item);
     bool getNewPassword(const QString& name, QByteArray& passwd);
-
-private Q_SLOTS:
     void reloadUsers();
     void reloadGroups();
+
+private Q_SLOTS:
     void onAdd();
     void onDelete();
     void onEditProperties();
     void onChangePasswd();
+    void reload();
+    void onRowActivated(const QModelIndex& index);
 
 private:
     Ui::MainWindow ui;

--- a/lxqt-admin-user/mainwindow.ui
+++ b/lxqt-admin-user/mainwindow.ui
@@ -15,7 +15,16 @@
   </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QVBoxLayout" name="verticalLayout">
-    <property name="margin">
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
      <number>0</number>
     </property>
     <item>
@@ -42,9 +51,6 @@
           <property name="expandsOnDoubleClick">
            <bool>false</bool>
           </property>
-          <attribute name="headerStretchLastSection">
-           <bool>false</bool>
-          </attribute>
           <column>
            <property name="text">
             <string>Login Name</string>
@@ -107,6 +113,11 @@
             <string>Group ID</string>
            </property>
           </column>
+          <column>
+           <property name="text">
+            <string>Members</string>
+           </property>
+          </column>
          </widget>
         </item>
        </layout>
@@ -134,14 +145,14 @@
    <addaction name="actionAdd"/>
    <addaction name="actionDelete"/>
    <addaction name="actionProperties"/>
+   <addaction name="actionChangePasswd"/>
    <addaction name="actionRefresh"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
   <action name="actionAdd">
    <property name="icon">
     <iconset theme="list-add">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>Add</string>
@@ -153,8 +164,7 @@
   <action name="actionDelete">
    <property name="icon">
     <iconset theme="list-remove">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>Delete</string>
@@ -166,8 +176,7 @@
   <action name="actionProperties">
    <property name="icon">
     <iconset theme="document-properties">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>Properties</string>
@@ -179,14 +188,24 @@
   <action name="actionRefresh">
    <property name="icon">
     <iconset theme="view-refresh">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>Refresh</string>
    </property>
    <property name="toolTip">
     <string>Refresh the lists</string>
+   </property>
+  </action>
+  <action name="actionChangePasswd">
+   <property name="icon">
+    <iconset theme="dialog-password"/>
+   </property>
+   <property name="text">
+    <string>Change Password</string>
+   </property>
+   <property name="toolTip">
+    <string>Change password for the selected user or group</string>
    </property>
   </action>
  </widget>

--- a/lxqt-admin-user/org.lxqt.lxqt-admin-user.policy.in
+++ b/lxqt-admin-user/org.lxqt.lxqt-admin-user.policy.in
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+<policyconfig>
+
+  <action id="org.lxqt.lxqt-admin-user">
+    <message>Authentication is required for user administration</message>
+    <icon_name></icon_name>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">@CMAKE_INSTALL_PREFIX@/bin/lxqt-admin-user-helper</annotate>
+  </action>
+
+</policyconfig>

--- a/lxqt-admin-user/userdialog.cpp
+++ b/lxqt-admin-user/userdialog.cpp
@@ -20,18 +20,21 @@
 
 #include "userdialog.h"
 #include <QMessageBox>
+#include "usermanager.h"
 
 #define DEFAULT_UID_MIN 1000
 #define DEFAULT_UID_MAX 32768
 
-UserDialog::UserDialog(OobsUser* user, QWidget* parent):
-    QDialog(),
-    mUser(user ? OOBS_USER(g_object_ref(user)) : NULL),
+UserDialog::UserDialog(UserManager* userManager, UserInfo* user, QWidget* parent):
+    QDialog(parent),
+    mUserManager(userManager),
+    mUser(user),
     mFullNameChanged(false),
     mHomeDirChanged(false)
 {
     ui.setupUi(this);
 
+#if 0
     // load all groups
     OobsGroupsConfig* groupsConfig = OOBS_GROUPS_CONFIG(oobs_groups_config_get());
     OobsList* groups = oobs_groups_config_get_groups(groupsConfig);
@@ -46,11 +49,10 @@ UserDialog::UserDialog(OobsUser* user, QWidget* parent):
             valid = oobs_list_iter_next(groups, &it);
         }
     }
-
+#endif
     connect(ui.loginName, SIGNAL(textChanged(QString)), SLOT(onLoginNameChanged(QString)));
 
-    OobsUsersConfig* userConfig = OOBS_USERS_CONFIG(oobs_users_config_get());
-
+#if 0
     // add known shells to the combo box for selection
     GList* shells = oobs_users_config_get_available_shells(userConfig);
     for(GList* l = shells; l; l = l->next)
@@ -58,38 +60,23 @@ UserDialog::UserDialog(OobsUser* user, QWidget* parent):
         const char* shell = (const char*)l->data;
         ui.loginShell->addItem(QLatin1String(shell));
     }
-
+#endif
     if(user) // edit an existing user
     {
-        mOldUid = oobs_user_get_uid(user);
-        ui.loginName->setReadOnly(true);
-        ui.loginName->setText(oobs_user_get_login_name(user));
+        ui.loginName->setText(user->name());
         ui.changePasswd->setText(tr("Change password:"));
-        ui.uid->setValue(mOldUid);
-        ui.fullName->setText(oobs_user_get_full_name(user));
-        ui.loginShell->setEditText(oobs_user_get_shell(user));
-        ui.homeDir->setText(QString::fromLocal8Bit(oobs_user_get_home_directory(user)));
-
-        OobsGroup* group = oobs_user_get_main_group(user);
-        ui.mainGroup->setEditText(oobs_group_get_name(group));
+        ui.uid->setValue(user->uid());
+        ui.fullName->setText(user->fullName());
+        ui.loginShell->setEditText(user->shell());
+        ui.homeDir->setText(user->homeDir());
+        GroupInfo* group = userManager->findGroupInfo(user->gid());
+        if(group)
+            ui.mainGroup->setEditText(group->name());
     }
-    else // create a new user
-    {
-        mOldUid = -1;
-        ui.loginName->setReadOnly(false);
-        ui.loginName->setFocus();
-        ui.changePasswd->setChecked(true);
-        ui.uid->setValue(oobs_users_config_find_free_uid(userConfig, DEFAULT_UID_MIN, DEFAULT_UID_MAX));
-        ui.loginShell->setEditText(oobs_users_config_get_default_shell(userConfig));
-        ui.mainGroup->setCurrentIndex(-1);
-    }
-
 }
 
 UserDialog::~UserDialog()
 {
-    if(mUser)
-        g_object_unref(mUser);
 }
 
 void UserDialog::onLoginNameChanged(const QString& text)
@@ -121,38 +108,17 @@ void UserDialog::onHomeDirChanged(const QString& text)
 
 void UserDialog::accept()
 {
-    OobsUsersConfig* usersConfig = OOBS_USERS_CONFIG(oobs_users_config_get());
-    uid_t uid = ui.uid->value();
-    if(uid != mOldUid && oobs_users_config_is_uid_used(usersConfig, uid))
+    mUser->setUid(ui.uid->value());
+    bool createNew;
+    QString loginName = ui.loginName->text();
+    if(loginName.isEmpty())
     {
-        QMessageBox::critical(this, tr("Error"), tr("The user ID is in use."));
+        QMessageBox::critical(this, tr("Error"), tr("The user name cannot be empty."));
         return;
     }
+    mUser->setFullName(ui.fullName->text());
 
-    bool createNew;
-    if(mUser)
-        createNew = false;
-    else
-    {
-        createNew = true;
-        QByteArray loginName = ui.loginName->text().toLatin1();
-        if(loginName.isEmpty())
-        {
-            QMessageBox::critical(this, tr("Error"), tr("The user name cannot be empty."));
-            return;
-        }
-        if(oobs_users_config_is_login_used(usersConfig, loginName))
-        {
-            QMessageBox::critical(this, tr("Error"), tr("The user name is in use."));
-            return;
-        }
-        mUser = oobs_user_new(loginName);
-    }
-    oobs_user_set_uid(mUser, uid);
-
-    QByteArray fullName = ui.fullName->text().toUtf8();
-    oobs_user_set_full_name(mUser, fullName);
-
+#if 0
     // change password
     if(ui.changePasswd->isChecked())
     {
@@ -165,17 +131,16 @@ void UserDialog::accept()
         else
             oobs_user_set_password(mUser, passwd);
     }
+#endif
 
-    QByteArray homeDir = ui.homeDir->text().toLocal8Bit();
-    oobs_user_set_home_directory(mUser, homeDir);
+    mUser->setHomeDir(ui.homeDir->text());
 
     // main group
-    OobsGroupsConfig* groupsConfig = OOBS_GROUPS_CONFIG(oobs_groups_config_get());
-    QByteArray groupName = ui.mainGroup->currentText().toLatin1();
-    OobsGroup* group = oobs_groups_config_get_from_name(groupsConfig, groupName);
-    oobs_user_set_main_group(mUser, group);
-
-    if(!createNew)
-        oobs_object_commit_async(OOBS_OBJECT(mUser), NULL, NULL);
+    QString groupName = ui.mainGroup->currentText();
+    if(!groupName.isEmpty()) {
+        GroupInfo* group = mUserManager->findGroupInfo(groupName);
+        if(group)
+            mUser->setGid(group->gid());
+    }
     QDialog::accept();
 }

--- a/lxqt-admin-user/userdialog.cpp
+++ b/lxqt-admin-user/userdialog.cpp
@@ -45,7 +45,6 @@ UserDialog::UserDialog(UserManager* userManager, UserInfo* user, QWidget* parent
     if(user) // edit an existing user
     {
         ui.loginName->setText(user->name());
-        ui.changePasswd->setText(tr("Change password:"));
         ui.uid->setValue(user->uid());
         ui.fullName->setText(user->fullName());
         ui.loginShell->setEditText(user->shell());
@@ -98,21 +97,6 @@ void UserDialog::accept()
     }
     mUser->setName(loginName);
     mUser->setFullName(ui.fullName->text());
-
-#if 0
-    // change password
-    if(ui.changePasswd->isChecked())
-    {
-        QByteArray passwd = ui.passwd->text().toLatin1();
-        if(passwd.isEmpty()) // show warnings if the password is empty
-        {
-            if(QMessageBox::warning(this, tr("Confirm"), tr("Are you sure you want to use an \"empty password\" for the user?"), QMessageBox::Yes|QMessageBox::No) == QMessageBox::Yes)
-                oobs_user_set_password_empty(mUser, true);
-        }
-        else
-            oobs_user_set_password(mUser, passwd);
-    }
-#endif
 
     mUser->setHomeDir(ui.homeDir->text());
 

--- a/lxqt-admin-user/userdialog.cpp
+++ b/lxqt-admin-user/userdialog.cpp
@@ -109,13 +109,13 @@ void UserDialog::onHomeDirChanged(const QString& text)
 void UserDialog::accept()
 {
     mUser->setUid(ui.uid->value());
-    bool createNew;
     QString loginName = ui.loginName->text();
     if(loginName.isEmpty())
     {
         QMessageBox::critical(this, tr("Error"), tr("The user name cannot be empty."));
         return;
     }
+    mUser->setName(loginName);
     mUser->setFullName(ui.fullName->text());
 
 #if 0

--- a/lxqt-admin-user/userdialog.cpp
+++ b/lxqt-admin-user/userdialog.cpp
@@ -34,33 +34,14 @@ UserDialog::UserDialog(UserManager* userManager, UserInfo* user, QWidget* parent
 {
     ui.setupUi(this);
 
-#if 0
     // load all groups
-    OobsGroupsConfig* groupsConfig = OOBS_GROUPS_CONFIG(oobs_groups_config_get());
-    OobsList* groups = oobs_groups_config_get_groups(groupsConfig);
-    if(groups)
-    {
-        OobsListIter it;
-        gboolean valid = oobs_list_get_iter_first(groups, &it);
-        while(valid)
-        {
-            OobsGroup* group = OOBS_GROUP(oobs_list_get(groups, &it));
-            ui.mainGroup->addItem(oobs_group_get_name(group));
-            valid = oobs_list_iter_next(groups, &it);
-        }
+    for(const GroupInfo* group: mUserManager->groups()) {
+        ui.mainGroup->addItem(group->name());
     }
-#endif
     connect(ui.loginName, SIGNAL(textChanged(QString)), SLOT(onLoginNameChanged(QString)));
 
-#if 0
-    // add known shells to the combo box for selection
-    GList* shells = oobs_users_config_get_available_shells(userConfig);
-    for(GList* l = shells; l; l = l->next)
-    {
-        const char* shell = (const char*)l->data;
-        ui.loginShell->addItem(QLatin1String(shell));
-    }
-#endif
+    ui.loginShell->addItems(mUserManager->availableShells());
+
     if(user) // edit an existing user
     {
         ui.loginName->setText(user->name());

--- a/lxqt-admin-user/userdialog.h
+++ b/lxqt-admin-user/userdialog.h
@@ -48,13 +48,6 @@ private:
     UserManager* mUserManager;
     UserInfo* mUser;
 
-#if 0
-    QByteArray mOldLoginName;
-    QByteArray mOldFullName;
-    QByteArray mOldGroupName;
-    QByteArray mOldHomeDir;
-#endif
-
     bool mFullNameChanged;
     bool mHomeDirChanged;
 };

--- a/lxqt-admin-user/userdialog.h
+++ b/lxqt-admin-user/userdialog.h
@@ -23,22 +23,18 @@
 
 #include <QDialog>
 #include "ui_userdialog.h"
-#include <glib.h>
-#include <oobs/oobs-usersconfig.h>
-#include <oobs/oobs-groupsconfig.h>
+#include "usermanager.h"
+
+class UserManager;
+class UserInfo;
 
 class UserDialog : public QDialog
 {
     Q_OBJECT
 
 public:
-    UserDialog(OobsUser* user = NULL, QWidget* parent = NULL);
+    UserDialog(UserManager* userManager, UserInfo* user, QWidget* parent = nullptr);
     ~UserDialog();
-
-    OobsUser* user()
-    {
-        return mUser;
-    }
 
     virtual void accept();
 
@@ -49,8 +45,9 @@ private Q_SLOTS:
 
 private:
     Ui::UserDialog ui;
-    OobsUser* mUser;
-    uid_t mOldUid;
+    UserManager* mUserManager;
+    UserInfo* mUser;
+
 #if 0
     QByteArray mOldLoginName;
     QByteArray mOldFullName;

--- a/lxqt-admin-user/userdialog.ui
+++ b/lxqt-admin-user/userdialog.ui
@@ -27,16 +27,6 @@
        <property name="fieldGrowthPolicy">
         <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
        </property>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label_3">
-         <property name="text">
-          <string>Full name:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="QLineEdit" name="fullName"/>
-       </item>
        <item row="0" column="0">
         <widget class="QLabel" name="label">
          <property name="text">
@@ -48,23 +38,23 @@
         <widget class="QLineEdit" name="loginName"/>
        </item>
        <item row="1" column="0">
-        <widget class="QCheckBox" name="changePasswd">
+        <widget class="QLabel" name="label_3">
          <property name="text">
-          <string>Set password:</string>
+          <string>Full name:</string>
          </property>
         </widget>
        </item>
        <item row="1" column="1">
-        <widget class="QLineEdit" name="passwd">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="echoMode">
-          <enum>QLineEdit::Password</enum>
+        <widget class="QLineEdit" name="fullName"/>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>User ID:</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="3" column="1">
         <widget class="QSpinBox" name="uid">
          <property name="maximum">
           <number>32768</number>
@@ -72,20 +62,13 @@
         </widget>
        </item>
        <item row="4" column="0">
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>User ID:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0">
         <widget class="QLabel" name="label_5">
          <property name="text">
           <string>Main group:</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="4" column="1">
         <widget class="QComboBox" name="mainGroup">
          <property name="editable">
           <bool>true</bool>
@@ -170,22 +153,6 @@
     <hint type="destinationlabel">
      <x>286</x>
      <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>changePasswd</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>passwd</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>71</x>
-     <y>125</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>192</x>
-     <y>129</y>
     </hint>
    </hints>
   </connection>

--- a/lxqt-admin-user/userdialog.ui
+++ b/lxqt-admin-user/userdialog.ui
@@ -56,6 +56,9 @@
        </item>
        <item row="3" column="1">
         <widget class="QSpinBox" name="uid">
+         <property name="specialValueText">
+          <string>Default</string>
+         </property>
          <property name="maximum">
           <number>32768</number>
          </property>
@@ -72,6 +75,30 @@
         <widget class="QComboBox" name="mainGroup">
          <property name="editable">
           <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_3">
+      <attribute name="title">
+       <string>Groups</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QLabel" name="label_6">
+         <property name="text">
+          <string>The user belongs to the following groups:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QListWidget" name="groupList">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>1</verstretch>
+          </sizepolicy>
          </property>
         </widget>
        </item>

--- a/lxqt-admin-user/usermanager.cpp
+++ b/lxqt-admin-user/usermanager.cpp
@@ -214,9 +214,14 @@ bool UserManager::addGroup(GroupInfo* group) {
 bool UserManager::modifyGroup(GroupInfo* group, GroupInfo* newSettings) {
     if(!group || group->name().isEmpty() || !newSettings)
         return false;
-
-    // TODO
-    return false;
+    QStringList command;
+    command << QStringLiteral("groupmod");
+    if(newSettings->gid() != group->gid())
+        command << QStringLiteral("-g") << QString::number(newSettings->gid());
+    if(newSettings->name() != group->name())
+        command << QStringLiteral("-n") << newSettings->name();
+    command << group->name();
+    return pkexec(command);
 }
 
 bool UserManager::deleteGroup(GroupInfo* group) {

--- a/lxqt-admin-user/usermanager.cpp
+++ b/lxqt-admin-user/usermanager.cpp
@@ -1,0 +1,229 @@
+#include "usermanager.h"
+#include <QDebug>
+#include <algorithm>
+#include <QFileSystemWatcher>
+#include <QTimer>
+#include <QProcess>
+
+static const QString PASSWD_FILE = QStringLiteral("/etc/passwd");
+static const QString GROUP_FILE = QStringLiteral("/etc/group");
+
+UserManager::UserManager(QObject *parent):
+    QObject(parent),
+    mWatcher(new QFileSystemWatcher(QStringList() << PASSWD_FILE << GROUP_FILE, this))
+{
+    loadUsers();
+    loadGroups();
+    connect(mWatcher, &QFileSystemWatcher::fileChanged, this, &UserManager::onFileChanged);
+}
+
+UserManager::~UserManager() {
+    qDeleteAll(mUsers);
+    qDeleteAll(mGroups);
+}
+
+void UserManager::loadUsers()
+{
+    setpwent();
+    struct passwd * pw;
+    while((pw = getpwent())) {
+        UserInfo* user = new UserInfo(pw);
+        mUsers.append(user);
+        qDebug() << pw->pw_name << pw->pw_gecos;
+    }
+    endpwent();
+    std::sort(mUsers.begin(), mUsers.end(), [](UserInfo*& u1, UserInfo*& u2) {
+        return u1->name() < u2->name();
+    });
+}
+
+void UserManager::loadGroups()
+{
+    setgrent();
+    struct group * grp;
+    while((grp = getgrent())) {
+        GroupInfo* group = new GroupInfo(grp);
+        mGroups.append(group);
+        // add members of this group
+        for(char** member_name = grp->gr_mem; *member_name; ++member_name) {
+            group->addMember(*member_name);
+        }
+    }
+    endgrent();
+    std::sort(mGroups.begin(), mGroups.end(), [](GroupInfo* g1, GroupInfo* g2) {
+        return g1->name() < g2->name();
+    });
+}
+
+UserInfo* UserManager::findUserInfo(const char* name) {
+    auto it = std::find_if(mUsers.begin(), mUsers.end(), [name](const UserInfo* user) {
+        return user->name() == name;
+    });
+    return it != mUsers.end() ? *it : nullptr;
+}
+
+UserInfo* UserManager::findUserInfo(QString name) {
+    auto it = std::find_if(mUsers.begin(), mUsers.end(), [name](const UserInfo* user) {
+        return user->name() == name;
+    });
+    return it != mUsers.end() ? *it : nullptr;
+}
+
+UserInfo* UserManager::findUserInfo(uid_t uid) {
+    auto it = std::find_if(mUsers.begin(), mUsers.end(), [uid](const UserInfo* user) {
+        return user->uid() == uid;
+    });
+    return it != mUsers.end() ? *it : nullptr;
+}
+
+GroupInfo* UserManager::findGroupInfo(const char* name) {
+    auto it = std::find_if(mGroups.begin(), mGroups.end(), [name](const GroupInfo* group) {
+        return group->name() == name;
+    });
+    return it != mGroups.end() ? *it : nullptr;
+}
+
+GroupInfo* UserManager::findGroupInfo(QString name) {
+    auto it = std::find_if(mGroups.begin(), mGroups.end(), [name](const GroupInfo* group) {
+        return group->name() == name;
+    });
+    return it != mGroups.end() ? *it : nullptr;
+}
+
+GroupInfo* UserManager::findGroupInfo(gid_t gid) {
+    auto it = std::find_if(mGroups.begin(), mGroups.end(), [gid](const GroupInfo* group) {
+        return group->gid() == gid;
+    });
+    return it != mGroups.end() ? *it : nullptr;
+}
+
+void UserManager::reloadUsers() {
+    mWatcher->addPath(PASSWD_FILE);
+
+    qDeleteAll(mUsers);  // free the old User objects
+    mUsers.clear();
+    loadUsers();
+    Q_EMIT usersChanged();
+}
+
+void UserManager::reloadGroups() {
+    mWatcher->addPath(GROUP_FILE);
+
+    qDeleteAll(mGroups);  // free the old User objects
+    mGroups.clear();
+    loadUsers();
+    Q_EMIT groupsChanged();
+}
+
+void UserManager::onFileChanged(const QString &path) {
+    if(path == PASSWD_FILE) {
+        QTimer::singleShot(500, this, &UserManager::reloadUsers);
+        mWatcher->removePath(PASSWD_FILE);
+    }
+    else {
+        QTimer::singleShot(500, this, &UserManager::reloadGroups);
+        mWatcher->removePath(GROUP_FILE);
+    }
+}
+
+bool UserManager::pkexec(QStringList& command) {
+    QProcess process;
+    qDebug() << command;
+    process.start(QStringLiteral("pkexec"), command);
+    process.waitForFinished(-1);
+    return process.exitCode() == 0;
+}
+
+bool UserManager::addUser(UserInfo* user) {
+    if(!user || user->name().isEmpty() || 0 == user->uid())
+        return false;
+
+    // FIXME: parse /etc/login.defs to get max UID, max system UID...etc.
+
+    QStringList command;
+    command << QStringLiteral("useradd");
+    command << QStringLiteral("-u") << QString::number(user->uid());
+
+    if(!user->homeDir().isEmpty()) {
+        command << QStringLiteral("-d") << user->homeDir();
+        command << QStringLiteral("-m"); // create the user's home directory if it does not exist.
+    }
+    if(!user->shell().isEmpty()) {
+        command << QStringLiteral("-s") << user->shell();
+    }
+
+    if(!user->fullName().isEmpty())
+        command << QStringLiteral("-c") << user->fullName();
+    if(user->gid() != 0)
+        command << QStringLiteral("-g") << QString::number(user->gid());
+
+    command << user->name();
+    return pkexec(command);
+}
+
+bool UserManager::modifyUser(UserInfo* user, UserInfo* newSettings) {
+    if(!user || user->name().isEmpty() || !newSettings)
+        return false;
+
+    QStringList command;
+    command << QStringLiteral("usermod");
+    if(newSettings->uid() != user->uid())
+        command << QStringLiteral("-u") << QString::number(newSettings->uid());
+
+    if(newSettings->homeDir() != user->homeDir()) {
+        command << QStringLiteral("-d") << newSettings->homeDir();
+        // command << QStringLiteral("-m"); // create the user's home directory if it does not exist.
+    }
+    if(newSettings->shell() != user->shell()) {
+        command << QStringLiteral("-s") << newSettings->shell();
+    }
+
+    if(newSettings->fullName() != user->fullName())
+        command << QStringLiteral("-c") << newSettings->fullName();
+    if(newSettings->gid() != user->gid())
+        command << QStringLiteral("-g") << QString::number(newSettings->gid());
+
+    if(newSettings->name() != user->name())  // change login name
+        command << QStringLiteral("-l") << newSettings->name();
+
+    command << user->name();
+    return pkexec(command);
+}
+
+bool UserManager::deleteUser(UserInfo* user) {
+    if(!user || user->name().isEmpty())
+        return false;
+
+    QStringList command;
+    command << QStringLiteral("userdel");
+    command << user->name();
+    return pkexec(command);
+}
+
+bool UserManager::addGroup(GroupInfo* group) {
+    if(!group || group->name().isEmpty() || 0 == group->gid())
+        return false;
+
+    QStringList command;
+    command << QStringLiteral("groupadd");
+    command << QStringLiteral("-g") << QString::number(group->gid());
+    command << group->name();
+    return pkexec(command);
+}
+
+bool UserManager::modifyGroup(GroupInfo* group, GroupInfo* newSettings) {
+    if(!group || group->name().isEmpty() || !newSettings)
+        return false;
+
+    // TODO
+    return false;
+}
+
+bool UserManager::deleteGroup(GroupInfo* group) {
+    if(!group || group->name().isEmpty())
+        return false;
+    QStringList command;
+    command << QStringLiteral("groupdel");
+    command << group->name();
+    return pkexec(command);
+}

--- a/lxqt-admin-user/usermanager.cpp
+++ b/lxqt-admin-user/usermanager.cpp
@@ -47,7 +47,7 @@ void UserManager::loadGroups()
         mGroups.append(group);
         // add members of this group
         for(char** member_name = grp->gr_mem; *member_name; ++member_name) {
-            group->addMember(*member_name);
+            group->addMember(QString::fromLatin1(*member_name));
         }
     }
     endgrent();

--- a/lxqt-admin-user/usermanager.cpp
+++ b/lxqt-admin-user/usermanager.cpp
@@ -9,13 +9,13 @@
 
 static const QString PASSWD_FILE = QStringLiteral("/etc/passwd");
 static const QString GROUP_FILE = QStringLiteral("/etc/group");
+static const QString LOGIN_DEFS_FILE = QStringLiteral("/etc/login.defs");
 
 UserManager::UserManager(QObject *parent):
     QObject(parent),
     mWatcher(new QFileSystemWatcher(QStringList() << PASSWD_FILE << GROUP_FILE, this))
 {
-    loadUsers();
-    loadGroups();
+    loadUsersAndGroups();
     connect(mWatcher, &QFileSystemWatcher::fileChanged, this, &UserManager::onFileChanged);
 }
 
@@ -24,23 +24,9 @@ UserManager::~UserManager() {
     qDeleteAll(mGroups);
 }
 
-void UserManager::loadUsers()
+void UserManager::loadUsersAndGroups()
 {
-    setpwent();
-    struct passwd * pw;
-    while((pw = getpwent())) {
-        UserInfo* user = new UserInfo(pw);
-        mUsers.append(user);
-        // qDebug() << pw->pw_name << pw->pw_gecos;
-    }
-    endpwent();
-    std::sort(mUsers.begin(), mUsers.end(), [](UserInfo*& u1, UserInfo*& u2) {
-        return u1->name() < u2->name();
-    });
-}
-
-void UserManager::loadGroups()
-{
+    // load groups
     setgrent();
     struct group * grp;
     while((grp = getgrent())) {
@@ -55,7 +41,61 @@ void UserManager::loadGroups()
     std::sort(mGroups.begin(), mGroups.end(), [](GroupInfo* g1, GroupInfo* g2) {
         return g1->name() < g2->name();
     });
+
+    // load users
+    setpwent();
+    struct passwd * pw;
+    while((pw = getpwent())) {
+        UserInfo* user = new UserInfo(pw);
+        mUsers.append(user);
+        // add groups to this user
+        for(const GroupInfo* group: mGroups) {
+            if(group->hasMember(user->name())) {
+                user->addGroup(group->name());
+            }
+        }
+    }
+    endpwent();
+    std::sort(mUsers.begin(), mUsers.end(), [](UserInfo*& u1, UserInfo*& u2) {
+        return u1->name() < u2->name();
+    });
 }
+
+// load settings from /etc/login.defs
+void UserManager::loadLoginDefs() {
+    // FIXME: parse /etc/login.defs to get max UID, max system UID...etc.
+    QFile file(LOGIN_DEFS_FILE);
+    if(file.open(QIODevice::ReadOnly)) {
+        while(!file.atEnd()) {
+            QByteArray line = file.readLine().trimmed();
+            if(line.isEmpty() || line.startsWith('#'))
+                continue;
+            QStringList parts = QString::fromUtf8(line).split(QRegExp("\\s"), QString::SkipEmptyParts);
+            if(parts.length() >= 2) {
+                QString& key = parts[0];
+                QString& val = parts[1];
+                if(key == QLatin1Literal("SYS_UID_MIN")) {
+                }
+                else if(key == QLatin1Literal("SYS_UID_MAX")) {
+                }
+                else if(key == QLatin1Literal("UID_MIN")) {
+                }
+                else if(key == QLatin1Literal("UID_MAX")) {
+                }
+                else if(key == QLatin1Literal("SYS_GID_MIN")) {
+                }
+                else if(key == QLatin1Literal("SYS_GID_MAX")) {
+                }
+                else if(key == QLatin1Literal("GID_MIN")) {
+                }
+                else if(key == QLatin1Literal("GID_MAX")) {
+                }
+            }
+        }
+        file.close();
+    }
+}
+
 
 UserInfo* UserManager::findUserInfo(const char* name) {
     auto it = std::find_if(mUsers.begin(), mUsers.end(), [name](const UserInfo* user) {
@@ -99,33 +139,30 @@ GroupInfo* UserManager::findGroupInfo(gid_t gid) {
     return it != mGroups.end() ? *it : nullptr;
 }
 
-void UserManager::reloadUsers() {
+void UserManager::reload() {
     mWatcher->addPath(PASSWD_FILE);
-
-    qDeleteAll(mUsers);  // free the old User objects
-    mUsers.clear();
-    loadUsers();
-    Q_EMIT usersChanged();
-}
-
-void UserManager::reloadGroups() {
     mWatcher->addPath(GROUP_FILE);
 
-    qDeleteAll(mGroups);  // free the old User objects
+    qDeleteAll(mUsers);  // free the old UserInfo objects
+    mUsers.clear();
+
+    qDeleteAll(mGroups);  // free the old GroupInfo objects
     mGroups.clear();
-    loadUsers();
-    Q_EMIT groupsChanged();
+
+    loadUsersAndGroups();
+    Q_EMIT changed();
 }
 
 void UserManager::onFileChanged(const QString &path) {
-    if(path == PASSWD_FILE) {
-        QTimer::singleShot(500, this, &UserManager::reloadUsers);
-        mWatcher->removePath(PASSWD_FILE);
-    }
-    else {
-        QTimer::singleShot(500, this, &UserManager::reloadGroups);
-        mWatcher->removePath(GROUP_FILE);
-    }
+    // QFileSystemWatcher is very broken and has a ridiculous design.
+    // we get "fileChanged()" when the file is deleted or modified,
+    // but there is no way to distinguish them. If the file is deleted,
+    // the QFileSystemWatcher stop working silently. Hence we workaround
+    // this by remove the paths from the watcher and add them back again
+    // to force the creation of new notifiers.
+    mWatcher->removePath(PASSWD_FILE);
+    mWatcher->removePath(GROUP_FILE);
+    QTimer::singleShot(500, this, &UserManager::reload);
 }
 
 bool UserManager::pkexec(const QStringList& command, const QByteArray& stdinData) {
@@ -137,7 +174,6 @@ bool UserManager::pkexec(const QStringList& command, const QByteArray& stdinData
         << command;
     process.start(QStringLiteral("pkexec"), args);
     if(!stdinData.isEmpty()) {
-        qDebug() << stdinData;
         process.waitForStarted();
         process.write(stdinData);
         process.waitForBytesWritten();
@@ -145,20 +181,17 @@ bool UserManager::pkexec(const QStringList& command, const QByteArray& stdinData
     }
     process.waitForFinished(-1);
     qDebug() << process.readAllStandardError();
-    qDebug() << process.readAllStandardOutput();
     return process.exitCode() == 0;
 }
 
 bool UserManager::addUser(UserInfo* user) {
-    if(!user || user->name().isEmpty() || 0 == user->uid())
+    if(!user || user->name().isEmpty())
         return false;
-
-    // FIXME: parse /etc/login.defs to get max UID, max system UID...etc.
-
     QStringList command;
     command << QStringLiteral("useradd");
-    command << QStringLiteral("-u") << QString::number(user->uid());
-
+    if(user->uid() != 0) {
+        command << QStringLiteral("-u") << QString::number(user->uid());
+    }
     if(!user->homeDir().isEmpty()) {
         command << QStringLiteral("-d") << user->homeDir();
         command << QStringLiteral("-m"); // create the user's home directory if it does not exist.
@@ -166,12 +199,15 @@ bool UserManager::addUser(UserInfo* user) {
     if(!user->shell().isEmpty()) {
         command << QStringLiteral("-s") << user->shell();
     }
-
-    if(!user->fullName().isEmpty())
+    if(!user->fullName().isEmpty()) {
         command << QStringLiteral("-c") << user->fullName();
-    if(user->gid() != 0)
+    }
+    if(user->gid() != 0) {
         command << QStringLiteral("-g") << QString::number(user->gid());
-
+    }
+    if(!user->groups().isEmpty()) {  // set group membership
+        command << QStringLiteral("-G") << user->groups().join(',');
+    }
     command << user->name();
     return pkexec(command);
 }
@@ -200,6 +236,10 @@ bool UserManager::modifyUser(UserInfo* user, UserInfo* newSettings) {
 
     if(newSettings->name() != user->name())  // change login name
         command << QStringLiteral("-l") << newSettings->name();
+
+    if(newSettings->groups() != user->groups()) {  // change group membership
+        command << QStringLiteral("-G") << newSettings->groups().join(',');
+    }
 
     command << user->name();
     return pkexec(command);
@@ -238,12 +278,14 @@ bool UserManager::changePassword(UserInfo* user, QByteArray newPasswd) {
 }
 
 bool UserManager::addGroup(GroupInfo* group) {
-    if(!group || group->name().isEmpty() || 0 == group->gid())
+    if(!group || group->name().isEmpty())
         return false;
 
     QStringList command;
     command << QStringLiteral("groupadd");
-    command << QStringLiteral("-g") << QString::number(group->gid());
+    if(group->gid() != 0) {
+        command << QStringLiteral("-g") << QString::number(group->gid());
+    }
     command << group->name();
     return pkexec(command);
 }
@@ -258,7 +300,19 @@ bool UserManager::modifyGroup(GroupInfo* group, GroupInfo* newSettings) {
     if(newSettings->name() != group->name())
         command << QStringLiteral("-n") << newSettings->name();
     command << group->name();
-    return pkexec(command);
+    if(!pkexec(command))
+        return false;
+
+    // if group members are changed, use gpasswd to reset members
+    if(newSettings->members() != group->members()) {
+        command.clear();
+        command << QStringLiteral("gpasswd");
+        command << QStringLiteral("-M");  // Set the list of group members.
+        command << newSettings->members().join(',');
+        command << group->name();
+        return pkexec(command);
+    }
+    return true;
 }
 
 bool UserManager::deleteGroup(GroupInfo* group) {
@@ -282,7 +336,6 @@ bool UserManager::changePassword(GroupInfo* group, QByteArray newPasswd) {
     stdinData += "\n";
     return pkexec(command, stdinData);
 }
-
 
 const QStringList& UserManager::availableShells() {
     if(mAvailableShells.isEmpty()) {

--- a/lxqt-admin-user/usermanager.h
+++ b/lxqt-admin-user/usermanager.h
@@ -143,6 +143,8 @@ public:
         return mGroups;
     }
 
+    const QStringList& availableShells();
+
     bool addUser(UserInfo* user);
     bool modifyUser(UserInfo* user, UserInfo* newSettings);
     bool deleteUser(UserInfo* user);
@@ -164,7 +166,7 @@ public:
 private:
     void loadUsers();
     void loadGroups();
-    bool pkexec(QStringList& command);
+    bool pkexec(const QStringList &command);
 
 Q_SIGNALS:
     void usersChanged();
@@ -179,6 +181,7 @@ private:
     QList<UserInfo*> mUsers;
     QList<GroupInfo*> mGroups;
     QFileSystemWatcher* mWatcher;
+    QStringList mAvailableShells;
 };
 
 #endif // USERMANAGER_H

--- a/lxqt-admin-user/usermanager.h
+++ b/lxqt-admin-user/usermanager.h
@@ -67,6 +67,26 @@ public:
         mHomeDir = homeDir;
     }
 
+    const QStringList& groups() const {
+        return mGroups;
+    }
+
+    void addGroup(const QString& group) {
+        mGroups.append(group);
+    }
+
+    void removeGroup(const QString& group) {
+        mGroups.removeOne(group);
+    }
+
+    void removeAllGroups() {
+        mGroups.clear();
+    }
+
+    bool hasGroup(const QString& group) {
+        return mGroups.contains(group);
+    }
+
 private:
     uid_t mUid;
     gid_t mGid;
@@ -74,6 +94,7 @@ private:
     QString mFullName;
     QString mShell;
     QString mHomeDir;
+    QStringList mGroups;
 };
 
 class GroupInfo
@@ -117,6 +138,14 @@ public:
         mMembers.removeOne(userName);
     }
 
+    void removeAllMemberss() {
+        mMembers.clear();
+    }
+
+    bool hasMember(const QString& userName) const {
+        return mMembers.contains(userName);
+    }
+
 private:
     gid_t mGid;
     QString mName;
@@ -150,7 +179,7 @@ public:
     bool deleteGroup(GroupInfo* group);
     bool changePassword(GroupInfo* group, QByteArray newPasswd);
 
-    // FIXME: add APIs to change group membership
+    // FIXME: add APIs to change group membership with "gpasswd"
 
     UserInfo* findUserInfo(const char* name);
     UserInfo* findUserInfo(QString name);
@@ -161,18 +190,16 @@ public:
     GroupInfo* findGroupInfo(gid_t gid);
 
 private:
-    void loadUsers();
-    void loadGroups();
+    void loadUsersAndGroups();
+    void loadLoginDefs();
     bool pkexec(const QStringList &command, const QByteArray &stdinData = QByteArray());
 
 Q_SIGNALS:
-    void usersChanged();
-    void groupsChanged();
+    void changed();
 
 protected Q_SLOTS:
     void onFileChanged(const QString &path);
-    void reloadUsers();
-    void reloadGroups();
+    void reload();
 
 private:
     QList<UserInfo*> mUsers;

--- a/lxqt-admin-user/usermanager.h
+++ b/lxqt-admin-user/usermanager.h
@@ -1,0 +1,184 @@
+#ifndef USERMANAGER_H
+#define USERMANAGER_H
+
+#include <QObject>
+#include <sys/types.h>
+#include <pwd.h>
+#include <grp.h>
+
+class QFileSystemWatcher;
+
+class UserInfo
+{
+public:
+    explicit UserInfo():mUid(0), mGid(0) {
+    }
+    explicit UserInfo(struct passwd* pw):
+        mUid(pw->pw_uid),
+        mGid(pw->pw_gid),
+        mName(QString::fromLatin1(pw->pw_name)),
+        mFullName(QString::fromUtf8(pw->pw_gecos)),
+        mShell(QString::fromLocal8Bit(pw->pw_shell)),
+        mHomeDir(QString::fromLocal8Bit(pw->pw_dir))
+    {
+    }
+
+    uid_t uid()const {
+        return mUid;
+    }
+    void setUid(uid_t uid) {
+        mUid = uid;
+    }
+
+    gid_t gid() const {
+        return mGid;
+    }
+
+    void setGid(gid_t gid) {
+        mGid = gid;
+    }
+
+    QString name() const {
+        return mName;
+    }
+
+    void setName(const QString& name) {
+        mName = name;
+    }
+
+    QString fullName() const {
+        return mFullName;
+    }
+    void setFullName(const QString& fullName) {
+        mFullName = fullName;
+    }
+
+    QString shell() const {
+        return mShell;
+    }
+    void setShell(const QString& shell) {
+        mShell = shell;
+    }
+
+    QString homeDir() const {
+        return mHomeDir;
+    }
+    void setHomeDir(const QString& homeDir) {
+        mHomeDir = homeDir;
+    }
+
+    QByteArray passwd() const {
+        return mPasswd;
+    }
+
+private:
+    uid_t mUid;
+    gid_t mGid;
+    QString mName;
+    QString mFullName;
+    QString mShell;
+    QString mHomeDir;
+    QByteArray mPasswd;
+};
+
+class GroupInfo
+{
+public:
+    explicit GroupInfo(): mGid(0) {
+    }
+    explicit GroupInfo(struct group* grp):
+        mGid(grp->gr_gid),
+        mName(grp->gr_name)
+    {
+    }
+
+    gid_t gid() const {
+        return mGid;
+    }
+    void setGid(gid_t gid) {
+        mGid = gid;
+    }
+
+    QString name() const {
+        return mName;
+    }
+    void setName(const QString& name) {
+        mName = name;
+    }
+
+    QStringList members() const {
+        return mMembers;
+    }
+
+    void setMembers(const QStringList& members) {
+        mMembers = members;
+    }
+
+    void addMember(const QString& userName) {
+        mMembers.append(userName);
+    }
+
+    void removeMember(const QString& userName) {
+        mMembers.removeOne(userName);
+    }
+
+private:
+    gid_t mGid;
+    QString mName;
+    QStringList mMembers;
+};
+
+class UserManager : public QObject
+{
+    Q_OBJECT
+public:
+    explicit UserManager(QObject *parent = 0);
+    ~UserManager();
+
+    const QList<UserInfo*>& users() const {
+        return mUsers;
+    }
+
+    const QList<GroupInfo*>& groups() const {
+        return mGroups;
+    }
+
+    bool addUser(UserInfo* user);
+    bool modifyUser(UserInfo* user, UserInfo* newSettings);
+    bool deleteUser(UserInfo* user);
+
+    bool addGroup(GroupInfo* group);
+    bool modifyGroup(GroupInfo* group, GroupInfo* newSettings);
+    bool deleteGroup(GroupInfo* group);
+
+    // FIXME: add APIs to change group membership
+
+    UserInfo* findUserInfo(const char* name);
+    UserInfo* findUserInfo(QString name);
+    UserInfo* findUserInfo(uid_t uid);
+
+    GroupInfo* findGroupInfo(const char* name);
+    GroupInfo* findGroupInfo(QString name);
+    GroupInfo* findGroupInfo(gid_t gid);
+
+private:
+    void loadUsers();
+    void loadGroups();
+    bool pkexec(QStringList& command);
+
+Q_SIGNALS:
+    void usersChanged();
+    void groupsChanged();
+
+protected Q_SLOTS:
+    void onFileChanged(const QString &path);
+    void reloadUsers();
+    void reloadGroups();
+
+private:
+    QList<UserInfo*> mUsers;
+    QList<GroupInfo*> mGroups;
+    QFileSystemWatcher* mWatcher;
+};
+
+#endif // USERMANAGER_H

--- a/lxqt-admin-user/usermanager.h
+++ b/lxqt-admin-user/usermanager.h
@@ -2,6 +2,7 @@
 #define USERMANAGER_H
 
 #include <QObject>
+#include <QStringList>
 #include <sys/types.h>
 #include <pwd.h>
 #include <grp.h>

--- a/lxqt-admin-user/usermanager.h
+++ b/lxqt-admin-user/usermanager.h
@@ -67,10 +67,6 @@ public:
         mHomeDir = homeDir;
     }
 
-    QByteArray passwd() const {
-        return mPasswd;
-    }
-
 private:
     uid_t mUid;
     gid_t mGid;
@@ -78,7 +74,6 @@ private:
     QString mFullName;
     QString mShell;
     QString mHomeDir;
-    QByteArray mPasswd;
 };
 
 class GroupInfo
@@ -148,10 +143,12 @@ public:
     bool addUser(UserInfo* user);
     bool modifyUser(UserInfo* user, UserInfo* newSettings);
     bool deleteUser(UserInfo* user);
+    bool changePassword(UserInfo* user, QByteArray newPasswd);
 
     bool addGroup(GroupInfo* group);
     bool modifyGroup(GroupInfo* group, GroupInfo* newSettings);
     bool deleteGroup(GroupInfo* group);
+    bool changePassword(GroupInfo* group, QByteArray newPasswd);
 
     // FIXME: add APIs to change group membership
 
@@ -166,7 +163,7 @@ public:
 private:
     void loadUsers();
     void loadGroups();
-    bool pkexec(const QStringList &command);
+    bool pkexec(const QStringList &command, const QByteArray &stdinData = QByteArray());
 
 Q_SIGNALS:
     void usersChanged();

--- a/lxqt-admin-user/usermanager.h
+++ b/lxqt-admin-user/usermanager.h
@@ -106,7 +106,7 @@ public:
         mName = name;
     }
 
-    QStringList members() const {
+    const QStringList& members() const {
         return mMembers;
     }
 


### PR DESCRIPTION
Today I got some time to finish my work in progress.
Now lxqt-admin is completely free from liboobs.
The date-time management part is using systemd.
Gnome account service is very bloated, unnecessarily complicated, and insecure (passing user password to usermod via command line). In addition, it lack supports for managing groups.
So finally the user management part is written from scratch with the aid of polkit.
Now this tool is Linux-only, but extension to support BSD is possible.
It should work out-of-the-box for a Linux system, but some error handling are not complete.
@jleclanche @palinek @paulolieuthier @pmattern @tsujan @luis-pereira @agaida ... or anyone who is available, I need your help to review this.
No more liboobs. This package can be included by modern distros again.
Cheers!