### PR TITLE
lxqt-admin-user: Fix a change password crash

### DIFF
--- a/lxqt-admin-user/mainwindow.cpp
+++ b/lxqt-admin-user/mainwindow.cpp
@@ -201,12 +201,18 @@ void MainWindow::onChangePasswd() {
     {
         QTreeWidgetItem* item = ui.userList->currentItem();
         user = userFromItem(item);
+        if (!user)
+            return;
+
         name = user->name();
     }
     else if(ui.tabWidget->currentIndex() == PageGroups)
     {
         QTreeWidgetItem* item = ui.groupList->currentItem();
         group = groupFromItem(item);
+        if (!group)
+            return;
+
         name = group->name();
     }
 


### PR DESCRIPTION
When no user/group is selected we end up dereferencing a null pointer.
Just protect against it.