### PR TITLE
Change icons of lxqt-admin-apps

### DIFF
--- a/lxqt-admin-time/lxqt-admin-time.desktop.in
+++ b/lxqt-admin-time/lxqt-admin-time.desktop.in
@@ -4,7 +4,7 @@ Name=Date and Time
 GenericName=Date and Time Settings
 Comment=Configure the date and time of your system
 Exec=lxqt-admin-time
-Icon=preferences-system
+Icon=preferences-system-time
 Categories=Settings;System;DesktopSettings;Qt;LXQt;
 OnlyShowIn=LXQt;
 

--- a/lxqt-admin-user/lxqt-admin-user.desktop.in
+++ b/lxqt-admin-user/lxqt-admin-user.desktop.in
@@ -4,7 +4,7 @@ Name=Users and Groups
 GenericName=User and Group Settings
 Comment=Configure the users and groups of your system
 Exec=lxqt-admin-user
-Icon=preferences-system
+Icon=system-users
 Categories=Settings;System;DesktopSettings;Qt;LXQt;
 OnlyShowIn=LXQt;
 


### PR DESCRIPTION
Change the lxqt-admin-user icon to system-users and the
lxqt-admin-time icon to preferences-system-time.
These icons are widely supported by icon themes.

This modification was discussed in issue lxde/lxqt#576